### PR TITLE
Add ParseToNullable method that wraps TryParse methods

### DIFF
--- a/Magenic.SharedKernel.Tests/ParserTests.cs
+++ b/Magenic.SharedKernel.Tests/ParserTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using static Magenic.SharedKernel.Parser;
+
+namespace Magenic.SharedKernel.Tests
+{
+    public class ParserTests
+    {
+        #region Public Methods
+
+        public static IEnumerable<object[]> GetTestData()
+        {
+            yield return new object[] { "845", (TryParseDelegate<int>) int.TryParse };
+            yield return new object[] { "-845", (TryParseDelegate<int>) int.TryParse };
+            yield return new object[] { "abc", (TryParseDelegate<int>) int.TryParse };
+            yield return new object[] { "1.8", (TryParseDelegate<int>) int.TryParse };
+            yield return new object[] { "1.8", (TryParseDelegate<double>) double.TryParse };
+            yield return new object[] { "1.8", (TryParseDelegate<float>) float.TryParse };
+            yield return new object[] { "abc", (TryParseDelegate<DateTime>) DateTime.TryParse };
+            yield return new object[] { "2017-01-01", (TryParseDelegate<DateTime>) DateTime.TryParse };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestData))]
+        public void Parser_SameAsTryParse<T>(string str, TryParseDelegate<T> method) where T: struct
+        {
+            var actual = ParseToNullable(str, method);
+            T expected;
+            if (method(str, out expected))
+            {
+                Assert.Equal(expected, actual);
+            }
+            else
+            {
+                Assert.Equal(null, actual);
+            }
+        }
+        #endregion
+    }
+}

--- a/Magenic.SharedKernel/Parser.cs
+++ b/Magenic.SharedKernel/Parser.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Globalization;
+using System.Numerics;
+
+namespace Magenic.SharedKernel
+{
+    /// <summary>
+    /// A class to hold parser methods that return a nullable result rather than use an out argument
+    /// </summary>
+    public static class Parser
+    {
+        #region Public Methods
+        /// <summary>
+        /// Delegate for the TryParse methods
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="s"></param>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        public delegate bool TryParseDelegate<T>(string s, out T result);
+
+        /// <summary>
+        /// Returns a nullable value based on the given tryParse delegate and string
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="s"></param>
+        /// <param name="tryParse"></param>
+        /// <returns></returns>
+        public static T? ParseToNullable<T>(string s, TryParseDelegate<T> tryParse) where T : struct
+        {
+            if (tryParse(s, out T result))
+            {
+                return result;
+            }
+            return null;
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
The `ParseToNullable` method takes a `TryParseDelegate` and a string value and returns a nullable object. The `TryParseDelegate` matches the signature of the basic `TryParse` methods (eg. `int.TryParse`).

Example usage:
```
var parsedValue = ParseToNullable(strToParse, int.TryParse);
```

`TryParse` methods that have additional arguments can be wrapped to still use the same delegate.